### PR TITLE
Fix round robin module naming and example execution

### DIFF
--- a/implementations/python/load_balancing_algorithms/round_robin.py
+++ b/implementations/python/load_balancing_algorithms/round_robin.py
@@ -7,10 +7,11 @@ class RoundRobin:
         self.current_index = (self.current_index + 1) % len(self.servers)
         return self.servers[self.current_index]
 
-# Example usage
-servers = ["Server1", "Server2", "Server3"]
-load_balancer = RoundRobin(servers)
+if __name__ == "__main__":
+    servers = ["Server1", "Server2", "Server3"]
+    load_balancer = RoundRobin(servers)
 
-for i in range(6):
-    server = load_balancer.get_next_server()
-    print(f"Request {i + 1} -> {server}")
+    for i in range(6):
+        server = load_balancer.get_next_server()
+        print(f"Request {i + 1} -> {server}")
+


### PR DESCRIPTION
## Summary
- Rename misnamed `round_robin.py.py` to `round_robin.py` for correct imports
- Prevent example code from running on import by adding `__main__` guard

## Testing
- `python implementations/python/load_balancing_algorithms/round_robin.py`
- `python - <<'PY'
import importlib.util
spec = importlib.util.spec_from_file_location('round_robin', 'implementations/python/load_balancing_algorithms/round_robin.py')
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)
module.RoundRobin(['X','Y']).get_next_server()
print('import succeeded')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68962ee37bb08321b6615673d50a13fb